### PR TITLE
[spike] demo ...attributes working in glimmer-vm

### DIFF
--- a/packages/@glimmer/integration-tests/lib/suites/components.ts
+++ b/packages/@glimmer/integration-tests/lib/suites/components.ts
@@ -285,7 +285,11 @@ export class BasicComponents extends RenderTest {
   })
   'invoking curried component with attributes via angle brackets (invocation classes merge)'() {
     this.registerHelper('hash', (_positional, named) => named);
-    this.registerComponent('Glimmer', 'Foo', '<p class="default" ...attributes>hello world!</p>');
+    this.registerComponent(
+      'Glimmer',
+      'Foo',
+      '<p class="default" ...attributes>hello world!</p><p ...attributes class="default">hello world!</p>'
+    );
     this.render({
       layout: '<@stuff.Foo class="invocation" />',
       args: {
@@ -293,7 +297,9 @@ export class BasicComponents extends RenderTest {
       },
     });
 
-    this.assertHTML(`<div><p class="default invocation">hello world!</p></div>`);
+    this.assertHTML(
+      `<div><p class="default invocation">hello world!</p><p class="invocation default">hello world!</p></div>`
+    );
     this.assertStableRerender();
   }
 


### PR DESCRIPTION
I tried to write a failing test for https://github.com/emberjs/ember.js/issues/17692 in `glimmer-vm`, but it appears to be working. This test passes with these changes

<img width="1422" alt="screen shot 2019-03-02 at 15 19 31" src="https://user-images.githubusercontent.com/2526/53683914-99ba6480-3cfe-11e9-86e8-037277425354.png">
